### PR TITLE
Add missing header includes?

### DIFF
--- a/src/util/robin_hood.hpp
+++ b/src/util/robin_hood.hpp
@@ -47,6 +47,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <limits>
 
 // #define ROBIN_HOOD_LOG_ENABLED
 #ifdef ROBIN_HOOD_LOG_ENABLED

--- a/src/util/sys/thread_group.hpp
+++ b/src/util/sys/thread_group.hpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <list>
+#include <optional>
 #include <thread>
 #include <functional>
 


### PR DESCRIPTION
Necessary for the build on my system.

Perhaps tested systems incidentally include these via another header?